### PR TITLE
ci: improve GitHub Actions security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,26 +1,43 @@
 name: ci
 
+permissions: {}
+
 on:
   push:
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
       - run: go build .
 
   goreleaser:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
       - run: goreleaser check
 
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
       - run: golangci-lint run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
 name: release
 
+permissions: {}
+
 on:
   push:
     branches:
@@ -8,6 +10,7 @@ on:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write # for create a release
       pull-requests: write # for open a pull request
@@ -25,12 +28,14 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.should-release == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write # for upload release assets
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: ./.github/actions/setup
       - run: goreleaser release --clean


### PR DESCRIPTION
## Summary
- Add security best practices to GitHub Actions workflows
- Fix all zizmor and ghalint security warnings

## Changes
- Add workflow-level `permissions: {}` to minimize default permissions
- Add `timeout-minutes` to all jobs (10min for CI jobs, 15min for release)
- Add `persist-credentials: false` to all checkout actions  
- Set explicit `permissions: { contents: read }` for CI jobs

## Test plan
- [x] Run `zizmor --persona=auditor .` - no findings
- [x] Run `ghalint run` - no errors
- [x] All existing CI checks should continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)